### PR TITLE
Make testNoteExporter work

### DIFF
--- a/converter/NoteExporter.js
+++ b/converter/NoteExporter.js
@@ -10,6 +10,17 @@ function NoteExporter() {
   });
 }
 
+NoteExporter.Prototype = function() {
+  this.convertDocument = function(doc) {
+    var body = doc.get('body');
+    var elements = this.convertContainer(body, this.state.containerId);
+    var out = elements.map(function(el) {
+      return el.outerHTML;
+    });
+    return out.join('');
+  };
+};
+
 HTMLExporter.extend(NoteExporter);
 
 module.exports = NoteExporter;


### PR DESCRIPTION
testNoteExporter fails with

```
/home/jmjf/dev/substance/examples/node_modules/substance/model/DOMExporter.js:61
    throw new Error('This method is abstract');
    ^

Error: This method is abstract
```

Added `convertDocument()` to NoteExporter.js and it works, providing a plain HTML export. Based on the example at [DOMExporter.js L52](https://github.com/substance/substance/blob/master/model/DOMExporter.js#L52). The trick that took a while to figure out was that I needed to pass the body, not the doc itself. 
