### PR TITLE
Added CodeEditor example.

### DIFF
--- a/code-editor/CodeEditorExampleConfig.js
+++ b/code-editor/CodeEditorExampleConfig.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var ProseEditorPackage = require('substance/packages/prose-editor/ProseEditorPackage');
+var ScriptPackage = require('./script/ScriptPackage');
+
+module.exports = {
+  name: 'code-editor-example',
+  configure: function(config) {
+    config.import(ProseEditorPackage);
+    config.import(ScriptPackage);
+  }
+};

--- a/code-editor/app.js
+++ b/code-editor/app.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var Component = require('substance/ui/Component');
+var ProseEditor = require('substance/packages/prose-editor/ProseEditor');
+var Configurator = require('substance/util/Configurator');
+var DocumentSession = require('substance/model/DocumentSession');
+
+var fixture = require('./fixture');
+var configurator = new Configurator(require('./CodeEditorExampleConfig'));
+
+function App() {
+  App.super.apply(this, arguments);
+}
+
+App.Prototype = function() {
+  this.render = function($$) {
+    var el = $$('div').addClass('app');
+    el.append($$(ProseEditor, {
+      documentSession: this.props.documentSession,
+      configurator: configurator
+    }));
+    return el;
+  };
+};
+
+Component.extend(App);
+
+window.onload = function() {
+  // Creates a ProseArticle based on the ProseEditorConfig
+  var doc = configurator.createArticle(fixture);
+  var documentSession = new DocumentSession(doc);
+  Component.mount(App, { documentSession: documentSession }, 'body');
+};

--- a/code-editor/app.scss
+++ b/code-editor/app.scss
@@ -11,16 +11,3 @@ $fa-font-path:  "../fonts" !default;
 body {
   overflow: hidden;
 }
-
-.sc-editor .sc-surface.body {
-  padding: 40px;
-
-  > * + * {
-    margin-bottom: 20px;
-  }
-
-  .sc-paragraph {
-    padding-bottom: 0px !important;
-  }
-
-}

--- a/code-editor/app.scss
+++ b/code-editor/app.scss
@@ -1,0 +1,26 @@
+$fa-font-path:  "../fonts" !default;
+@import '../node_modules/font-awesome/scss/font-awesome';
+@import '../node_modules/substance/styles/base/index';
+
+// Substance modules
+@import '../node_modules/substance/styles/components/_all';
+@import '../node_modules/substance/packages/_all';
+
+@import './script/_script';
+
+body {
+  overflow: hidden;
+}
+
+.sc-editor .sc-surface.body {
+  padding: 40px;
+
+  > * + * {
+    margin-bottom: 20px;
+  }
+
+  .sc-paragraph {
+    padding-bottom: 0px !important;
+  }
+
+}

--- a/code-editor/fixture.js
+++ b/code-editor/fixture.js
@@ -1,0 +1,43 @@
+'use strict';
+
+module.exports = function(tx) {
+  var body = tx.get('body');
+  tx.create({
+    id: 'h1',
+    type: 'heading',
+    level: 1,
+    content: 'Embedding a 3rdParty CodeEditor'
+  });
+  body.show('h1');
+
+  tx.create({
+    id: 'intro',
+    type: 'paragraph',
+    content: [
+      'It is possible to use 3rd party components, a code editor for instance, such as ACE.',
+      'The editor us wrapped into an IsolatedNode which makes it independent from the main word-processor interface.',
+    ].join(" ")
+  });
+  body.show('intro');
+
+  tx.create({
+    id: 's1',
+    type: 'script',
+    language: 'js',
+    source: [
+      "function hello_world() {",
+      "  alert('Hello World!');",
+      "}"
+    ].join("\n")
+  });
+  body.show('s1');
+
+  tx.create({
+    id: 'the-end',
+    type: 'paragraph',
+    content: [
+      "That's it."
+    ].join(" ")
+  });
+  body.show('the-end');
+};

--- a/code-editor/fixture.js
+++ b/code-editor/fixture.js
@@ -23,7 +23,7 @@ module.exports = function(tx) {
   tx.create({
     id: 's1',
     type: 'script',
-    language: 'js',
+    language: 'javascript',
     source: [
       "function hello_world() {",
       "  alert('Hello World!');",

--- a/code-editor/index.html
+++ b/code-editor/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Embedded CodeEditor</title>
+    <meta charset="UTF-8">
+    <link href='app.css' rel='stylesheet' type='text/css'/>
+    <script src="/ace/ace.js" type="text/javascript" charset="utf-8"></script>
+    <script src='app.js'></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/code-editor/script/InsertScriptCommand.js
+++ b/code-editor/script/InsertScriptCommand.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var InsertNodeCommand = require('substance/ui/InsertNodeCommand');
+
+function InsertScriptCommand() {
+  InsertScriptCommand.super.apply(this, arguments);
+}
+
+InsertScriptCommand.Prototype = function() {
+
+  this.createNodeData = function() {
+    return {
+      type: 'script',
+      language: 'js',
+      content: ''
+    };
+  };
+
+};
+
+InsertNodeCommand.extend(InsertScriptCommand);
+
+InsertScriptCommand.static.name = 'insert-script';
+
+module.exports = InsertScriptCommand;

--- a/code-editor/script/InsertScriptCommand.js
+++ b/code-editor/script/InsertScriptCommand.js
@@ -11,7 +11,7 @@ InsertScriptCommand.Prototype = function() {
   this.createNodeData = function() {
     return {
       type: 'script',
-      language: 'js',
+      language: 'javascript',
       content: ''
     };
   };

--- a/code-editor/script/InsertScriptTool.js
+++ b/code-editor/script/InsertScriptTool.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var Tool = require('substance/ui/Tool');
+
+function InsertScriptTool() {
+  InsertScriptTool.super.apply(this, arguments);
+}
+
+Tool.extend(InsertScriptTool);
+
+InsertScriptTool.static.name = 'insert-script';
+
+module.exports = InsertScriptTool;

--- a/code-editor/script/ScriptEditor.js
+++ b/code-editor/script/ScriptEditor.js
@@ -5,6 +5,8 @@ var Component = require('substance/ui/Component');
 
 function ScriptEditor() {
   ScriptEditor.super.apply(this, arguments);
+
+  this.editor = null;
 }
 
 ScriptEditor.Prototype = function() {
@@ -15,26 +17,66 @@ ScriptEditor.Prototype = function() {
   };
 
   this.didMount = function() {
+    var node = this.props.node;
     var editor = ace.edit(this.refs.source.getNativeElement());
     // editor.setTheme("ace/theme/monokai");
     editor.setOptions({
-        maxLines: Infinity
+      maxLines: Infinity,
     });
-    editor.getSession().setMode("ace/mode/javascript");
-    this.aceEditor = editor;
+    editor.$blockScrolling = Infinity;
+    editor.getSession().setMode("ace/mode/" + node.language);
+    // TODO: don't we need to dispose the editor?
+    // For now we update the model only on blur
+    // Option 1: updating on blur
+    //   pro: one change for the whole code editing session
+    //   con: very implicit, very late, hard to get selection right
+    editor.on('blur', this._updateModelOnBlur.bind(this));
+
+    editor.commands.addCommand({
+      name: 'escape',
+      bindKey: {win: 'Escape', mac: 'Escape'},
+      exec: function(editor) {
+        this.send('escape');
+        editor.blur();
+      }.bind(this),
+      readOnly: true // false if this command should not apply in readOnly mode
+    });
+
+    this.editor = editor;
+
+    this.props.node.on('source:changed', this._onModelChange, this);
+  };
+
+  this.dispose = function() {
+    this.props.node.off(this);
+    this.editor.destroy();
   };
 
   this.render = function($$) {
     var node = this.props.node;
-
     var el = $$('div').addClass('sc-script-editor');
     el.append(
       $$('div').append(node.source).ref('source')
     );
-
     return el;
   };
 
+  this._updateModelOnBlur = function() {
+    var editor = this.editor;
+    var nodeId = this.props.node.id;
+    var source = editor.getValue();
+    if (source !== this.props.node.source) {
+      this.context.surface.transaction(function(tx) {
+        tx.set([nodeId, 'source'], editor.getValue());
+      }, { source: this, skipSelection: true });
+    }
+  };
+
+  this._onModelChange = function(change, info) {
+    if (info.source !== this) {
+      this.editor.setValue(this.props.node.source, -1);
+    }
+  };
 };
 
 Component.extend(ScriptEditor);

--- a/code-editor/script/ScriptEditor.js
+++ b/code-editor/script/ScriptEditor.js
@@ -1,0 +1,44 @@
+/* globals ace */
+'use strict';
+
+var Component = require('substance/ui/Component');
+
+function ScriptEditor() {
+  ScriptEditor.super.apply(this, arguments);
+}
+
+ScriptEditor.Prototype = function() {
+
+  // don't rerender because this would destroy ACE
+  this.shouldRerender = function() {
+    return false;
+  };
+
+  this.didMount = function() {
+    var editor = ace.edit(this.refs.source.getNativeElement());
+    // editor.setTheme("ace/theme/monokai");
+    editor.setOptions({
+        maxLines: Infinity
+    });
+    editor.getSession().setMode("ace/mode/javascript");
+    this.aceEditor = editor;
+  };
+
+  this.render = function($$) {
+    var node = this.props.node;
+
+    var el = $$('div').addClass('sc-script-editor');
+    el.append(
+      $$('div').append(node.source).ref('source')
+    );
+
+    return el;
+  };
+
+};
+
+Component.extend(ScriptEditor);
+
+ScriptEditor.static.fullWidth = true;
+
+module.exports = ScriptEditor;

--- a/code-editor/script/ScriptNode.js
+++ b/code-editor/script/ScriptNode.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var BlockNode = require('substance/model/BlockNode');
+
+function ScriptNode() {
+  ScriptNode.super.apply(this, arguments);
+}
+
+BlockNode.extend(ScriptNode);
+
+ScriptNode.static.name = 'script';
+
+ScriptNode.static.defineSchema({
+  'language': 'string',
+  'source': 'text'
+});
+
+module.exports = ScriptNode;

--- a/code-editor/script/ScriptPackage.js
+++ b/code-editor/script/ScriptPackage.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var ScriptNode = require('./ScriptNode');
+var ScriptEditor = require('./ScriptEditor');
+var InsertScriptCommand = require('./InsertScriptCommand');
+var InsertScriptTool = require('./InsertScriptTool');
+
+module.exports = {
+  name: 'script',
+  configure: function(config) {
+    config.addNode(ScriptNode);
+    config.addComponent(ScriptNode.static.name, ScriptEditor);
+    config.addCommand(InsertScriptCommand);
+    config.addTool(InsertScriptTool);
+    config.addIcon(InsertScriptCommand.static.name, { 'fontawesome': 'fa-code' });
+  }
+};

--- a/code-editor/script/_script.scss
+++ b/code-editor/script/_script.scss
@@ -1,0 +1,4 @@
+.sc-script-editor {
+  background: #efefef;
+  padding: 5px 10px;
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ var through2 = require('through2');
 var rename = require('gulp-rename');
 var eslint = require('gulp-eslint');
 
-var demos = ['collabwriter', 'input', 'form', 'focused', 'tables', 'images', 'macros'];
+var demos = ['code-editor', 'collabwriter', 'input', 'form', 'focused', 'tables', 'images', 'macros'];
 
 gulp.task('lint', function() {
   return gulp.src([
@@ -25,6 +25,10 @@ gulp.task('assets', function () {
   });
   gulp.src('index.html')
         .pipe(gulp.dest('dist'));
+  gulp.src('node_modules/font-awesome/fonts/*')
+    .pipe(gulp.dest('./dist/fonts'));
+  gulp.src('node_modules/ace-builds/src-min/*')
+    .pipe(gulp.dest('./dist/ace'));
 });
 
 gulp.task('sass', function() {
@@ -34,9 +38,6 @@ gulp.task('sass', function() {
       .pipe(rename('app.css'))
       .pipe(gulp.dest('./dist/'+demoFolder));
   });
-
-  gulp.src('node_modules/font-awesome/fonts/*')
-    .pipe(gulp.dest('./dist/fonts'));
 });
 
 gulp.task('browserify', function() {

--- a/index.html
+++ b/index.html
@@ -7,4 +7,5 @@
   <li><a href="./tables">Tables</a></li>
   <li><a href="./images">Images</a></li>
   <li><a href="./macros">Text Macros</a></li>
+  <li><a href="./code-editor">Code-Editor</a></li>
 </ul>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lodash": "4.2.1"
   },
   "devDependencies": {
+    "ace-builds": "^1.2.2",
     "browserify": "^10.2.4",
     "express": "4.13.1",
     "font-awesome": "4.5.0",

--- a/server.js
+++ b/server.js
@@ -10,7 +10,7 @@ var server = require('substance/util/server');
 server.serveStyles(app, '/collabwriter/app.css', path.join(__dirname, 'collabwriter', 'app.scss'));
 server.serveJS(app, '/collabwriter/app.js', path.join(__dirname, 'collabwriter', 'app.js'));
 
-['collabwriter', 'images', 'input', 'macros', 'form', 'focused', 'tables'].forEach(function(folder) {
+['code-editor', 'collabwriter', 'images', 'input', 'macros', 'form', 'focused', 'tables'].forEach(function(folder) {
   server.serveStyles(app, '/'+folder+'/app.css', path.join(__dirname, folder, 'app.scss'));
   server.serveJS(app, '/'+folder+'/app.js', path.join(__dirname, folder, 'app.js'));
 });
@@ -18,6 +18,10 @@ server.serveJS(app, '/collabwriter/app.js', path.join(__dirname, 'collabwriter',
 // Serve static files
 app.use(express.static(path.join(__dirname)));
 app.use('/fonts', express.static(path.join(__dirname, 'node_modules/font-awesome/fonts')));
+
+// for the code-editor example
+app.use('/ace', express.static(path.join(__dirname, 'node_modules/ace-builds/src')));
+
 
 app.listen(port, function() {
   console.log("Substance Examples running on port " + port);


### PR DESCRIPTION
Using ACE:
- unfortunately no browserify compatible build
- but still pretty easy to use: `npm install ace-builds` and serving statically
- seems to work together with IsolatedNodes well, out-of-the-box. 
