### PR TITLE
Instructs dev to observe examples on port 5555

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install
 $ npm start
 ```
 
-Now you can navigate to [http://localhost:5000](http://localhost:5000)
+Now you can navigate to [http://localhost:5555](http://localhost:5555)
 
 ## Questions
 


### PR DESCRIPTION
The make file currently sets the server port to `5555` instead of `5000`, as the current documentation suggests. 